### PR TITLE
language engine is now fixed

### DIFF
--- a/src/locale/index.ts
+++ b/src/locale/index.ts
@@ -11,7 +11,7 @@ export default new (class LanguageEngine {
       this.Language = path;
       localStorage.setItem("language", path);
     } else {
-      this.getLangFromLS();
+      this.Language = this.getLangFromLS();
     }
   }
 


### PR DESCRIPTION
Bug was being caused by calling the method that restores the language from local storage without assigning its return, as pointed out by @dalagnol.